### PR TITLE
Fixed support for logging to a file instead of STDOUT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 log/
 /labs
+*.log

--- a/bin/fake_sns
+++ b/bin/fake_sns
@@ -13,7 +13,8 @@ options = {
   daemonize: false,
   database: nil,
   auto_drain: false,
-  purge_on_drain: false
+  purge_on_drain: false,
+  log: nil
 }
 
 parser = OptionParser.new do |o|
@@ -41,7 +42,7 @@ parser = OptionParser.new do |o|
     options[:daemonize] = daemonize
   end
 
-  o.on '-v', '--[no]-verbose', 'Shows input parameters and output XML' do |verbose|
+  o.on '-v', '--[no-]verbose', 'Shows input parameters and output XML' do |verbose|
     options[:verbose] = verbose
   end
 
@@ -51,6 +52,10 @@ parser = OptionParser.new do |o|
 
   o.on '-x', '--purge-on-drain', 'Purges messages on drain' do |purge_on_drain|
     options[:purge_on_drain] = purge_on_drain
+  end
+
+  o.on '-L', '--log FILENAME', 'Logs to a file (STDOUT by default)' do |log|
+    options[:log] = log
   end
 
   o.on_tail '--version', 'Shows the version' do

--- a/lib/fake_sns.rb
+++ b/lib/fake_sns.rb
@@ -46,9 +46,11 @@ module FakeSNS
     app
   end
 
-  def self.enable_logging(log)
-    $stdout.reopen(log, 'w:utf-8')
-    $stderr.reopen(log, 'w:utf-8')
+  def self.enable_logging(app, log_filename)
+    log = File.new log_filename, 'a'
+    $stdout.reopen(log)
+    $stderr.reopen(log)
+    $stdout.sync = $stderr.sync = true
     app.enable :logging
   end
 


### PR DESCRIPTION
* Added option to specify a log file given by `--log FILENAME`
* Fixed redirection of `stdout` and `stderr` to file by disabled buffered IO 
* Fixed `--verbose` option, where a typo required `---verbose`