### PR TITLE
Replaced with an app wide constant in `lib/fake_sns`

### DIFF
--- a/bin/fake_sns
+++ b/bin/fake_sns
@@ -96,4 +96,4 @@ if (pid = options[:pid])
   File.open(pid, 'w') { |f| f.write(Process.pid) }
 end
 
-FakeSNS.server(options, File.join(__dir__, '..')).run!
+FakeSNS.server(options).run!

--- a/lib/fake_sns.rb
+++ b/lib/fake_sns.rb
@@ -1,6 +1,8 @@
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
+ROOT_DIR = File.join(__dir__, '..')
+
 require 'virtus'
 require 'verbose_hash_fetch'
 
@@ -39,9 +41,8 @@ end
 
 # FakeSNS server
 module FakeSNS
-  def self.server(options, root_dir = Dir.pwd)
+  def self.server(options)
     app = Server
-    app.set :root_dir, root_dir
     enable_logging(app, options[:log]) unless options[:log].nil?
     enable_verbose(app) if options[:verbose]
     set_options(app, options)

--- a/lib/fake_sns/server.rb
+++ b/lib/fake_sns/server.rb
@@ -116,7 +116,7 @@ module FakeSNS
 
     get %r{/signing-certificate(.pem)?} do
       content_type 'text/plain', charset: 'utf-8'
-      File.read(File.join(settings.root_dir, 'keys/cert.pem'))
+      File.read(File.join(ROOT_DIR, 'keys/cert.pem'))
     end
   end
 end

--- a/lib/fake_sns/signature.rb
+++ b/lib/fake_sns/signature.rb
@@ -33,7 +33,7 @@ module FakeSNS
     end
 
     def key
-      key_contents = File.read('keys/private.pem')
+      key_contents = File.read(File.join(ROOT_DIR, 'keys/private.pem'))
       OpenSSL::PKey::RSA.new(key_contents)
     end
 


### PR DESCRIPTION
Realised we reference two keys relatively and converted solution to use
app constant instead.