### PR TITLE
Improved logging of messages

### DIFF
--- a/lib/fake_sns/deliver_message.rb
+++ b/lib/fake_sns/deliver_message.rb
@@ -83,7 +83,7 @@ module FakeSNS
 
     def http_or_https
       $log.info(self.to_s) { "Notifying endpoint '#{endpoint}'" }
-      $log.debug(self.to_s) { "Sending #{message}" }
+      $log.debug(self.to_s) { "Sending #{message.attributes}" }
 
       Faraday.new.post(endpoint) do |f|
         begin
@@ -109,12 +109,12 @@ module FakeSNS
           }
         rescue Faraday::TimeoutError => e
           $log.fatal(self.to_s) { "Failed to notify endpoint '#{endpoint}'" }
-          $log.fatal(self.to_s) { "Not sent: #{message}" }
+          $log.fatal(self.to_s) { "Not sent: #{message.attributes}" }
         end
       end
 
       $log.info(self.to_s) { "Notified endpoint '#{endpoint}'" }
-      $log.debug(self.to_s) { "Sent #{message}" }
+      $log.debug(self.to_s) { "Sent #{message.attributes}" }
     end
   end
 end

--- a/lib/fake_sns/server.rb
+++ b/lib/fake_sns/server.rb
@@ -27,10 +27,10 @@ module FakeSNS
       database.transaction do
         begin
           response = database.perform(action, params)
-          puts "New message: #{params}"
+          $log.info(self.to_s) { "New message: #{params}" }
           status 200
           if action == 'Publish' && settings.auto_drain
-            puts "Draining message #{response.message_id}"
+            $log.info(self.to_s) { "Draining message #{response.message_id}" }
             drain_message(response.message_id)
           end
           erb :"#{response.template}.xml", scope: response


### PR DESCRIPTION
We were given the messages class name instead of a messages attrs.
I've modified this so that we log the message attributes instead
of the ID of the Message object.