### PR TITLE
Added concurrency to delivery of messages

### DIFF
--- a/fake_sns.gemspec
+++ b/fake_sns.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0'
   spec.add_dependency 'hosts', '~> 0.1.1'
   spec.add_dependency 'sudo', '~> 0.2.0'
+  spec.add_dependency 'concurrent-ruby', '~> 1.1.5'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'fake_sqs', '~> 0.2'

--- a/lib/fake_sns/constants.rb
+++ b/lib/fake_sns/constants.rb
@@ -1,3 +1,4 @@
 module FakeSNS
   ROOT_DIR = File.join(__dir__, '../..')
+  ASYNC = true
 end

--- a/lib/fake_sns/deliver_message.rb
+++ b/lib/fake_sns/deliver_message.rb
@@ -1,6 +1,7 @@
 require 'forwardable'
 require 'faraday'
 require 'base64'
+require 'concurrent'
 
 module FakeSNS
   # Delivers messages to the correct target
@@ -85,36 +86,40 @@ module FakeSNS
       $log.info(self.to_s) { "Notifying endpoint '#{endpoint}'" }
       $log.debug(self.to_s) { "Sending #{message}" }
 
-      Faraday.new.post(endpoint) do |f|
-        begin
-          f.body = {
-            'Type'             => message.type,
-            'MessageId'        => message.id,
-            'TopicArn'         => message.topic_arn,
-            'Subject'          => message.subject,
-            'Message'          => message_contents,
-            'Timestamp'        => message.timestamp,
-            'SignatureVersion' => '1',
-            'Signature'        => Base64.strict_encode64(message.signature),
-            'SigningCertURL'   => signing_url,
-            'UnsubscribeURL'   => '', # TODO: url to unsubscribe URL on this server
-          }.to_json
+      promise = Concurrent::Promise.execute do
+        Faraday.new.post(endpoint) do |f|
+          begin
+            f.body = {
+                'Type'             => message.type,
+                'MessageId'        => message.id,
+                'TopicArn'         => message.topic_arn,
+                'Subject'          => message.subject,
+                'Message'          => message_contents,
+                'Timestamp'        => message.timestamp,
+                'SignatureVersion' => '1',
+                'Signature'        => Base64.strict_encode64(message.signature),
+                'SigningCertURL'   => signing_url,
+                'UnsubscribeURL'   => '', # TODO: url to unsubscribe URL on this server
+            }.to_json
 
-          f.headers = {
-            'x-amz-sns-message-type'     => 'Notification',
-            'x-amz-sns-message-id'       => message.id,
-            'x-amz-sns-topic-arn'        => message.topic_arn,
-            'x-amz-sns-subscription-arn' => arn,
-            'Content-Type'               => 'application/json'
-          }
-        rescue Faraday::TimeoutError => e
-          $log.fatal(self.to_s) { "Failed to notify endpoint '#{endpoint}'" }
-          $log.fatal(self.to_s) { "Not sent: #{message}" }
+            f.headers = {
+                'x-amz-sns-message-type'     => 'Notification',
+                'x-amz-sns-message-id'       => message.id,
+                'x-amz-sns-topic-arn'        => message.topic_arn,
+                'x-amz-sns-subscription-arn' => arn,
+                'Content-Type'               => 'application/json'
+            }
+          rescue Faraday::TimeoutError => e
+            $log.fatal(self.to_s) { "Failed to notify endpoint '#{endpoint}'" }
+            $log.fatal(self.to_s) { "Not sent: #{message}" }
+          end
         end
+      end.then do
+        $log.info(self.to_s) { "Notified endpoint '#{endpoint}'" }
+        $log.debug(self.to_s) { "Sent #{message}" }
       end
 
-      $log.info(self.to_s) { "Notified endpoint '#{endpoint}'" }
-      $log.debug(self.to_s) { "Sent #{message}" }
+      promise.value if FakeSNS::ASYNC
     end
   end
 end

--- a/lib/fake_sns/server.rb
+++ b/lib/fake_sns/server.rb
@@ -68,13 +68,12 @@ module FakeSNS
       begin
         database.transaction do
           database.each_deliverable_message do |subscription, message|
-            puts [subscription, message]
             DeliverMessage.call(
-              subscription: subscription,
-              message: message,
-              request: request,
-              config: config,
-              signing_url: signing_url
+                subscription: subscription,
+                message: message,
+                request: request,
+                config: config,
+                signing_url: signing_url
             )
             purge(message.id)
           end

--- a/spec/fake_sns/drain_spec.rb
+++ b/spec/fake_sns/drain_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe 'Drain messages', :sqs do
 
     app_runner.kill
 
+    sleep(0.1)
     expect(requests.size).to eq 1
     expect(requests.first).to match_json_expression(
       'Type'             => 'Notification',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'pry'
 
 module FakeSNS
   ROOT_DIR = File.join(__dir__, '..')
+  ASYNC = false
 end
 
 require 'fake_sns/test_integration'


### PR DESCRIPTION
The issue turned out to be a weird one. Our OAuth server sent out
a message as part of accepting a message. FakeSNS was waiting on
the first message to be processed before processing another. I've
made this concurrent so hopefully we won't see a hang.