### PR TITLE
Fixed issue with async flag in testing

### DIFF
--- a/lib/fake_sns/constants.rb
+++ b/lib/fake_sns/constants.rb
@@ -1,4 +1,4 @@
 module FakeSNS
   ROOT_DIR = File.join(__dir__, '../..')
-  ASYNC = true
+  ASYNC = ENV['RACK_ENV'] != 'test'
 end

--- a/lib/fake_sns/deliver_message.rb
+++ b/lib/fake_sns/deliver_message.rb
@@ -118,8 +118,10 @@ module FakeSNS
         $log.info(self.to_s) { "Notified endpoint '#{endpoint}'" }
         $log.debug(self.to_s) { "Sent #{message}" }
       end
-      
-      promise.value if FakeSNS::ASYNC
+
+      puts "Hello"
+      puts "Disabled async" unless FakeSNS::ASYNC
+      promise.value unless FakeSNS::ASYNC
     end
   end
 end


### PR DESCRIPTION
I'd wrongly assumed that I could override the FakeSNS::ASYNC const
in `spec_helper.rb`. The tests actually spawn a FakeSNS process so
that's not possible. But we can set the ASYNC flag to fall if the
`ENV['RACK_ENV']` flag is `'test'`.